### PR TITLE
fix: replace package.json git-urls with https-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/ease-crc/openease_threejs#readme",
   "dependencies": {
-    "ros3d": "git://github.com/RobotWebTools/ros3djs.git#develop"
+    "ros3d": "https://github.com/RobotWebTools/ros3djs.git#develop"
   }
 }


### PR DESCRIPTION
git-urls are not supported anymore (https://github.blog/2021-09-01-improving-git-protocol-security-github/), thus they need to be replaced with https-urls